### PR TITLE
[FEATURE] Add comment region for more robust comment replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ be able to use it again to update the visualization:
 > updates your PR. Adding content above the tag, or below the list is
 > safe though!
 
+#### Alternative: Use a stack comment region
+
+Using this alternative syntax does not suffer from the above caveaets.
+
+```md
+## Stack
+
+<!-- branch-stack-region-start -->
+<!-- branch-stack-region-end -->
+
+## Checklist
+
+[ ] Foo
+[ ] Bar
+[ ] Baz
+```
+
+
 ## Manual Configuration
 
 If you are using Git Town v11 and below, or are setting up the action for a repository

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -42,10 +42,12 @@ describe('updateDescription', () => {
     const expected = [
       '## Description',
       '',
-      '<!-- branch-stack -->',
+      '<!-- branch-stack-region-start -->',
       '',
       '- main',
       '  - \\#2',
+      '',
+      '<!-- branch-stack-region-end -->',
       '',
     ].join('\n')
 
@@ -103,6 +105,65 @@ There may be things here we don't want to overwrite.
       '',
       '- main',
       '  - \\#1',
+      '',
+      '## More Description',
+      '',
+    ].join('\n')
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should replace the comment region correctly', () => {
+    const description = `<!-- branch-stack-region-start -->
+<!-- branch-stack-region-end -->
+
+- [ ] this checklist
+- [ ] is going to be ok
+
+## More Description
+`
+    const output = ['- main', '  - \\#1'].join('\n')
+
+    const actual = updateDescription({ description, output })
+    const expected = [
+      '<!-- branch-stack-region-start -->',
+      '',
+      '- main',
+      '  - \\#1',
+      '',
+      '<!-- branch-stack-region-end -->',
+      '',
+      '- [ ] this checklist',
+      '- [ ] is going to be ok',
+      '',
+      '## More Description',
+      '',
+    ].join('\n')
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should replace the comment region correctly, even when no region end is specified', () => {
+    const description = `<!-- branch-stack-region-start -->
+
+- [ ] this checklist
+- [ ] is going to be ok
+
+## More Description
+`
+    const output = ['- main', '  - \\#1'].join('\n')
+
+    const actual = updateDescription({ description, output })
+    const expected = [
+      '<!-- branch-stack-region-start -->',
+      '',
+      '- main',
+      '  - \\#1',
+      '',
+      '<!-- branch-stack-region-end -->',
+      '',
+      '- [ ] this checklist',
+      '- [ ] is going to be ok',
       '',
       '## More Description',
       '',

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,6 +193,10 @@ export async function main({
   await Promise.allSettled(jobs.map((job) => job()))
 }
 
+const ANCHOR = '<!-- branch-stack -->'
+const ANCHOR_REGION_START = '<!-- branch-stack-region-start -->'
+const ANCHOR_REGION_END = '<!-- branch-stack-region-end -->'
+
 export function updateDescription({
   description,
   output,
@@ -200,34 +204,53 @@ export function updateDescription({
   description: string
   output: string
 }) {
-  const ANCHOR = '<!-- branch-stack -->'
-
   const descriptionAst = remark.parse(description)
-  const outputAst = remark.parse(`${ANCHOR}\n${output}`)
 
-  const anchorIndex = descriptionAst.children.findIndex(
+  let usingAnchorRegion = false
+  let anchorIndex = descriptionAst.children.findIndex(
     (node) => node.type === 'html' && node.value === ANCHOR
   )
 
+  if (anchorIndex === -1) {
+    anchorIndex = descriptionAst.children.findIndex(
+      (node) => node.type === 'html' && node.value === ANCHOR_REGION_START
+    )
+
+    usingAnchorRegion = anchorIndex !== -1
+  }
+
+  // if the anchor is the last ast node, set nearestListIndex to anchorIndex for proper splicing
+  let spliceEndIndex =
+    anchorIndex === descriptionAst.children.length - 1 ? anchorIndex : anchorIndex + 1
+
+  if (usingAnchorRegion) {
+    const endAnchorIndex = descriptionAst.children.findIndex(
+      (node) => node.type === 'html' && node.value === ANCHOR_REGION_END
+    )
+
+    spliceEndIndex = endAnchorIndex === -1 ? anchorIndex : endAnchorIndex
+  }
+
   const isMissingAnchor = anchorIndex === -1
+  const outputAst =
+    usingAnchorRegion || isMissingAnchor ?
+      remark.parse(`${ANCHOR_REGION_START}\n${output}\n${ANCHOR_REGION_END}`)
+    : remark.parse(`${ANCHOR}\n${output}`)
+
   if (isMissingAnchor) {
     descriptionAst.children.push(...outputAst.children)
 
     return remark.stringify(descriptionAst)
   }
 
-  // if the anchor is the last ast node, set nearestListIndex to anchorIndex for proper splicing
-  let nearestListIndex =
-    anchorIndex === descriptionAst.children.length - 1 ? anchorIndex : anchorIndex + 1
-
-  // NOTE: this will eat up any list node in direct succession to the anchor comment.
-  if (descriptionAst.children[nearestListIndex]?.type !== 'list') {
-    nearestListIndex = anchorIndex
+  // NOTE: when not using the region syntax, this will eat up any list node in direct succession to the anchor comment.
+  if (!usingAnchorRegion && descriptionAst.children[spliceEndIndex]?.type !== 'list') {
+    spliceEndIndex = anchorIndex
   }
 
   descriptionAst.children.splice(
     anchorIndex,
-    nearestListIndex - anchorIndex + 1,
+    spliceEndIndex - anchorIndex + 1,
     ...outputAst.children
   )
 


### PR DESCRIPTION
## Description

Adds a feature to use a comment region rather than a single comment. This is more robust and fixes the issue with clobbering lists which come after the stack comment.

> [!WARNING]
> Also changes the default behavior when there is no branch stack comment to use the region comment rather than the single comment.

## Stack

<!-- branch-stack -->
